### PR TITLE
Allow Z offset with ISO8601DateTimeTZStr

### DIFF
--- a/lib/MooseX/Types/ISO8601.pm
+++ b/lib/MooseX/Types/ISO8601.pm
@@ -51,7 +51,7 @@ use MooseX::Types 0.10 -declare => [qw(
 my $date_re =       qr/^(\d{4})-(\d{2})-(\d{2})$/;
 my $time_re =                               qr/^(\d{2}):(\d{2}):(\d{2})(?:(?:\.|,)(\d+))?Z?$/;
 my $datetime_re =   qr/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:(?:\.|,)(\d+))?Z?$/;
-my $datetimetz_re = qr/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:(?:\.|,)(\d+))?((?:\+|-)\d\d:\d\d)$/;
+my $datetimetz_re = qr/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:(?:\.|,)(\d+))?((?:(?:\+|-)\d\d:\d\d)|Z)$/;
 
 subtype ISO8601DateStr,
     as Str,

--- a/t/13_datetime_tz.t
+++ b/t/13_datetime_tz.t
@@ -7,7 +7,7 @@ use MooseX::Types::ISO8601 qw/
     ISO8601StrictDateTimeTZStr
 /;
 
-use Test::More tests => 9;
+use Test::More tests => 11;
 use Test::Deep;
 use Test::NoWarnings 1.04 ':early';
 
@@ -48,6 +48,14 @@ use Test::NoWarnings 1.04 ':early';
     # XXX - currently we don't generate nanosecond offsets for compatibility.
     note "DateTime into string";
     is(to_ISO8601DateTimeTZStr($datetime), "2011-02-03T01:05:06+01:30");
+}
+
+{
+    ok(is_ISO8601DateTimeTZStr('2013-02-21T02:00:00Z'),
+        'String with Z for zero UTC offset');
+    ok(is_ISO8601StrictDateTimeTZStr('2013-02-21T02:00:00Z'),
+        'String with Z for zero UTC offset with DateTime check');
+
 }
 
 {


### PR DESCRIPTION
"Z" is a zero offset from UTC, and as such, is fully specified.

RT #102870
