### PR TITLE
Describe time zone support

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for MooseX-Types-ISO8601
 
 {{$NEXT}}
+          - update docs wrt time zone support.
 
 0.19      2020-01-04 22:57:19Z
           - provide inlined versions of the types (thanks, Gregory Oschwald!)

--- a/dist.ini
+++ b/dist.ini
@@ -14,7 +14,6 @@ Test::ReportPrereqs.include[0] = Dist::CheckConflicts
 Test::ReportPrereqs.include[1] = namespace::clean
 Test::MinimumVersion.max_target_perl = 5.008003
 -remove = Test::PodSpelling
--remove = Test::Pod::No404s     ; http://state51.co.uk is unreachable? :(
 StaticInstall.dry_run = 0       ; we can safely set this here
 
 [Substitute]

--- a/dist.ini
+++ b/dist.ini
@@ -1,6 +1,6 @@
 name        = MooseX-Types-ISO8601
 author      = Tomas Doran (t0m) <bobtfish@bobtfish.net>
-author      = Dave Lambley <davel@state51.co.uk>
+author      = Dave Lambley <dlambley@cpan.org>
 copyright_holder = Tomas Doran
 license     = Perl_5
 copyright_year = 2009

--- a/lib/MooseX/Types/ISO8601.pm
+++ b/lib/MooseX/Types/ISO8601.pm
@@ -565,6 +565,6 @@ Specifically, there are missing features:
 
 =head1 ACKNOWLEDGEMENTS
 
-The development of this code was sponsored by my (Tom's) employer L<http://www.state51.co.uk>.
+The development of this code was sponsored by my (Tom's) employer L<http://www.state51.com/>.
 
 =cut

--- a/lib/MooseX/Types/ISO8601.pm
+++ b/lib/MooseX/Types/ISO8601.pm
@@ -547,7 +547,7 @@ This module is probably full of bugs; patches are very welcome.
 Specifically, there are missing features:
 
 =for :list
-* No timezone support - all times are assumed UTC
+* When no time-zone is specified, UTC is assumed. (Should floating timezone be used?)
 * No week number type
 * "Basic format", which lacks separator characters, is not supported for reading or writing.
 * Tests are rubbish.


### PR DESCRIPTION
We have claimed since 2009 that we don't support timezones, but support was added in 2012. 1b189ad3ba750837ec072b52b17bbdbee20ecefe

I have also updated links and email addresses.